### PR TITLE
Retrait des mises à jour effectuées sur les tables en postinstall du …

### DIFF
--- a/src/clients/admin_console.py
+++ b/src/clients/admin_console.py
@@ -30,12 +30,28 @@ class AdminConsoleClient:
 
     def init_db(self, db_name=f"{settings.DATABASE_NAME}"):
         """
-        Description: vue dédiée à supprimer et recréer les tables de la base de données, à vide.
+        Description:
+        Dédiée à supprimer et recréer les tables de la base de données, à vide.
         """
         self.app_view.init_db()
 
-    def flush_db(self, db_name=f"{settings.DATABASE_NAME}"):
+    def reset_db(self, db_name=f"{settings.DATABASE_NAME}"):
         """
-        Description: vue dédiée à supprimer les tables de la base de données.
+        Description:
+        Dédiée à supprimer les tables de la base de données.
         """
-        self.app_view.flush_db()
+        self.app_view.reset_db(db_name=db_name)
+
+    def database_postinstall_tasks(self, db_name=f"{settings.DATABASE_NAME}"):
+        """
+        Description:
+        Dédiée à mettre à jour les tables de la base de données après initialisation de l'application.
+        """
+        self.app_view.database_postinstall_tasks(db_name=db_name)
+
+    def database_postinstall_alter_tables(self, db_name=f"{settings.DATABASE_NAME}"):
+        """
+        Description:
+        Dédiée à forcer la mise à jour de valeurs par défaut de tables.
+        """
+        self.app_view.database_postinstall_alter_tables(db_name=db_name)

--- a/src/commands/init_commands.py
+++ b/src/commands/init_commands.py
@@ -132,14 +132,14 @@ def init_application():
 
     admin_console_client = AdminConsoleClient()
     admin_console_client.init_db()
-    admin_console_client = AdminConsoleClient(db_name=f"{settings.TEST_DATABASE_NAME}")
-    admin_console_client.init_db(db_name=f"{settings.TEST_DATABASE_NAME}")
     utils.display_postgresql_controls()
-    utils.database_postinstall_tasks()
-    utils.database_postinstall_tasks(db_name=f"{settings.TEST_DATABASE_NAME}")
-    utils.database_postinstall_alter_tables()
-    utils.database_postinstall_alter_tables(db_name=f"{settings.TEST_DATABASE_NAME}")
+    admin_console_client.database_postinstall_tasks()
+    admin_console_client.database_postinstall_alter_tables()
+    admin_console_client = AdminConsoleClient(db_name=f"{settings.TEST_DATABASE_NAME}")
+    admin_console_client.reset_db(db_name=f"{settings.TEST_DATABASE_NAME}")
+    admin_console_client.init_db(db_name=f"{settings.TEST_DATABASE_NAME}")
+    admin_console_client.database_postinstall_tasks(db_name=f"{settings.TEST_DATABASE_NAME}")
+    admin_console_client.database_postinstall_alter_tables(db_name=f"{settings.TEST_DATABASE_NAME}")
 
     # On peuple la base de données avec des données quelconques, pour le POC, en développement
-    # utils.dummy_database_creation()
     utils.dummy_database_creation(db_name=f"{settings.TEST_DATABASE_NAME}")

--- a/src/views/authentication_view.py
+++ b/src/views/authentication_view.py
@@ -34,14 +34,28 @@ class AuthenticationView:
             user_login, user_pwd, "", db_name=db_name
         )
 
-    def init_db(self):
+    def init_db(self, db_name=f"{settings.DATABASE_NAME}"):
         """
         Description: Dédié à aider au développement. On détruit et recrée les tables de la base de données.
         """
         self.db_initializer.init_db(self.engine)
 
-    def flush_db(self):
+    def reset_db(self, db_name=f"{settings.DATABASE_NAME}"):
         """
         Description: Dédié à aider au développement. On détruit les tables de la base de données.
         """
-        self.db_initializer.flush_db(self.engine)
+        self.db_initializer.reset_db(self.engine, db_name=db_name)
+
+    def database_postinstall_tasks(self, db_name=f"{settings.DATABASE_NAME}"):
+        """
+        Description:
+        Dédiée à mettre à jour les tables de la base de données après initialisation de l'application.
+        """
+        self.db_initializer.database_postinstall_tasks(db_name=db_name)
+
+    def database_postinstall_alter_tables(self, db_name=f"{settings.DATABASE_NAME}"):
+        """
+        Description:
+        Dédiée à forcer la mise à jour de valeurs par défaut de tables.
+        """
+        self.db_initializer.database_postinstall_alter_tables(db_name=db_name)


### PR DESCRIPTION
Retrait des mises à jour effectuées sur les tables en postinstall du fichier utils.py. 
Elles demeurent engagées depuis le module commands/init_commands. 
Mais c'est le controllers/DatabaseInitializerController qui porte la définition. 
Aussi on adapte la console clients/admin_console.py et views/authentication_view.py pour faire relais entre les 'commandes' et le 'controller'.