### PR TITLE
On échappe les caractères spéciaux dans les mots de passe. L'objet En…

### DIFF
--- a/src/controllers/database_initializer_controller.py
+++ b/src/controllers/database_initializer_controller.py
@@ -1,6 +1,7 @@
 import psycopg
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+import urllib.parse
 
 try:
     from src.models import models
@@ -38,8 +39,9 @@ class DatabaseInitializerController:
                 dprt = str(decoded_token["department"]).upper()
                 user_pwd = eval(f"settings.{dprt}_PWD")
 
+            password_with_specialchars_escape = urllib.parse.quote_plus(user_pwd)
             engine = create_engine(
-                f"postgresql+psycopg://{user_login}:{user_pwd}@localhost/{db_name}"
+                f"postgresql+psycopg://{user_login}:{password_with_specialchars_escape}@localhost/{db_name}"
             )
         except psycopg.OperationalError as error:
             print(f"[bold red][START CONTROL][/bold red] {error}")

--- a/src/controllers/database_read_controller.py
+++ b/src/controllers/database_read_controller.py
@@ -1,7 +1,7 @@
 """
 Un controleur avec toutes méthodes GET.
 """
-from sqlalchemy import create_engine
+
 try:
     from src.models import models
 except ModuleNotFoundError:


### PR DESCRIPTION
On échappe les caractères spéciaux dans les mots de passe. 
L'objet Engine de SQLAlchemy utilise une 'URL string' qui est fourni pour instancier ''l'application SQLAlchemy''. 
Tous caractères spéciaux doivent être échappés dans cette 'URL like'. 
Les tests se basent sur un mot de passe par défaut qui possède un @robase.