### PR TITLE
Permissions exclusives implémentées. Voir cahier des charges, par exe…

### DIFF
--- a/src/exceptions/exceptions.py
+++ b/src/exceptions/exceptions.py
@@ -11,6 +11,18 @@ class MissingUpdateParamException(Exception):
     pass
 
 
+class CommercialCollaboratorIsNotAssignedToClient(Exception):
+    pass
+
+
+class CommercialCollaboratorIsNotAssignedToContract(Exception):
+    pass
+
+
+class ContractNotFoundWithContractId(Exception):
+    pass
+
+
 class SupportCollaboratorIsNotAssignedToEvent(Exception):
     pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,24 @@ def get_valid_decoded_token_for_a_support_collaborator(mocker):
 
 
 @pytest.fixture
+def get_valid_decoded_token_for_a_support_collaborator_with_id_7(mocker):
+    expiration = datetime.utcnow() + timedelta(minutes=1)
+    dummy_payload_data = {
+        "registration_number": "af123456789",
+        "username": "Aliénor Vichum",
+        "department": "oc12_support",
+        "expiration": f'{expiration.strftime("%Y-%m-%d %H:%M:%S")}',
+    }
+    mocker.patch(
+        "controllers.jwt_controller.JwtController.get_decoded_token",
+        return_value=dummy_payload_data,
+    )
+    mocker.patch.object(JwtController, "does_a_valid_token_exist", return_value=True)
+    mocker.patch.object(JwtView, "get_decoded_token", return_value=dummy_payload_data)
+    return dummy_payload_data
+
+
+@pytest.fixture
 def get_unvalid_decoded_token(mocker):
     dummy_payload_data = {
         "registration_number": "Zaa123456789",
@@ -196,6 +214,35 @@ def dummy_event_data(request):
         "collaborator_id": "2",
     }
     return event
+
+
+@pytest.fixture(scope="session", autouse = True)
+def dummy_event_partial_data_1(request):
+    event_partial_dict = {
+        "event_id": "hob2023",
+        "collaborator_id": 5
+    }
+    return event_partial_dict
+
+
+@pytest.fixture(scope="session", autouse = True)
+def dummy_event_partial_data_2(request):
+    event_partial_dict = {
+        "event_id": "hob2023",
+        "attendees": "3500",
+        "notes": "Prévoir eau plate et gazeuse. Sirop et jus de fruits.",
+    }
+    return event_partial_dict
+
+
+@pytest.fixture(scope="session", autouse = True)
+def dummy_event_partial_data_3(request):
+    event_partial_dict = {
+        "event_id": "geg2021",
+        "attendees": "2500",
+        "notes": "Prévoir eau plate et gazeuse.",
+    }
+    return event_partial_dict
 
 
 @pytest.fixture(scope="session", autouse = True)

--- a/tests/views/test_create_views.py
+++ b/tests/views/test_create_views.py
@@ -138,7 +138,7 @@ contract_attributes_dict_1 = {
     "remain_amount_to_pay": "999.99",
     "status": "unsigned",
     "client_id": "1",
-    "collaborator_id": "2",
+    "collaborator_id": "1",
     "creation_date": "2023-07-15 22:00:00",
 }
 
@@ -162,7 +162,7 @@ event_attributes_dict_1 = {
     "client_id": "1",
     "contract_id": "1",
     "location_id": "2",
-    "collaborator_id": "2",
+    "collaborator_id": "1",
     "creation_date": "2023-07-15 22:00:00",
 }
 
@@ -407,22 +407,32 @@ def test_add_contract_view_with_support_profile(
         result = ConsoleClientForCreate(db_name).add_contract(custom_dict)
 
 
-@pytest.mark.parametrize(
-    "custom_dict", [event_attributes_dict_1, event_attributes_dict_2]
-)
-def test_add_event_view_with_commercial_profile(
-    get_runner, get_valid_decoded_token_for_a_commercial_collaborator, custom_dict
+def test_add_event_view_with_commercial_profile_when_assigned_contract(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     """
     Vérifier si un membre du service commercial peut ajouter un évènement.
     """
     try:
         db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_event(custom_dict)
+        result = ConsoleClientForCreate(db_name).add_event(event_attributes_dict_1)
         assert isinstance(result, int)
         assert result > 0
     except Exception as error:
         print(error)
+
+
+def test_add_event_view_with_commercial_profile_when_unassigned_contract(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
+):
+    """
+    Description:
+    Vérifier si un membre du service commercial peut ajouter un évènement
+    Il ne peut pas créer un évènement pour un contrat qu'il n'a pas signé
+    """
+    with pytest.raises(exceptions.SupportCollaboratorIsNotAssignedToEvent):
+        db_name = f"{settings.TEST_DATABASE_NAME}"
+        result = ConsoleClientForCreate(db_name).add_event(event_attributes_dict_2)
 
 
 @pytest.mark.parametrize(
@@ -487,6 +497,20 @@ def test_add_department_view_with_gestion_profile(
         assert result > 0
     except Exception as error:
         print(error)
+
+
+@pytest.mark.parametrize(
+    "custom_dict", [department_attributes_dict_1, department_attributes_dict_2]
+)
+def test_add_department_view_with_commercial_profile(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator, custom_dict
+):
+    """
+    Vérifier si un membre du service commercial peut ajouter un departement (service).
+    """
+    with pytest.raises(exceptions.InsufficientPrivilegeException):
+        db_name = f"{settings.TEST_DATABASE_NAME}"
+        result = ConsoleClientForCreate(db_name).add_department(custom_dict)
 
 
 @pytest.mark.parametrize(

--- a/tests/views/test_z_delete_views.py
+++ b/tests/views/test_z_delete_views.py
@@ -111,14 +111,14 @@ def test_delete_event_view_with_support_profile(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event("EV971")
+        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event("geg2021")
 
 
 def test_delete_event_view_with_gestion_profile(
     get_runner, get_valid_decoded_token_for_a_gestion_collaborator
 ):
     try:
-        dummy_events_list = ["FW971", "EV971"]
+        dummy_events_list = ["EV971"]
         for event in dummy_events_list:
             result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event(event)
             assert isinstance(result, int)


### PR DESCRIPTION
Permissions exclusives implémentées. 
Voir cahier des charges, par exemple un commercial ne peut mettre à jour qu'un client dont il est responsable. 
Ajout de 3 exceptions: CommercialCollaboratorIsNotAssignedToClient, CommercialCollaboratorIsNotAssignedToContract et ContractNotFoundWithContractId. 
Mise en concordance des id.