### PR TITLE
On vérifie qu'on ne peut pas supprimer d'élément dont la clef primair…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,24 @@ def get_valid_decoded_token_for_a_support_collaborator(mocker):
 
 
 @pytest.fixture
+def get_valid_decoded_token_for_a_support_collaborator_with_id_5(mocker):
+    expiration = datetime.utcnow() + timedelta(minutes=1)
+    dummy_payload_data = {
+        "registration_number": "ae123456789",
+        "username": "Aliénor Vichum",
+        "department": "oc12_support",
+        "expiration": f'{expiration.strftime("%Y-%m-%d %H:%M:%S")}',
+    }
+    mocker.patch(
+        "controllers.jwt_controller.JwtController.get_decoded_token",
+        return_value=dummy_payload_data,
+    )
+    mocker.patch.object(JwtController, "does_a_valid_token_exist", return_value=True)
+    mocker.patch.object(JwtView, "get_decoded_token", return_value=dummy_payload_data)
+    return dummy_payload_data
+
+
+@pytest.fixture
 def get_valid_decoded_token_for_a_support_collaborator_with_id_7(mocker):
     expiration = datetime.utcnow() + timedelta(minutes=1)
     dummy_payload_data = {

--- a/tests/views/test_create_views.py
+++ b/tests/views/test_create_views.py
@@ -23,7 +23,7 @@ except ModuleNotFoundError:
 location_attributes_dict_1 = {
     "location_id": "PL24250",
     "adresse": "3 rue de la tannerie",
-    "complement_adresse": "La meule en bière",
+    "complement_adresse": "Voie de la bière",
     "code_postal": "24250",
     "ville": "Plurien",
     "pays": "France",
@@ -33,7 +33,7 @@ location_attributes_dict_1 = {
 location_attributes_dict_2 = {
     "location_id": "CAL13540",
     "adresse": "8 avenue des rillettes",
-    "complement_adresse": "Voie de l'amande",
+    "complement_adresse": "mur nord",
     "code_postal": "13540",
     "ville": "Gardanne",
     "pays": "France",
@@ -253,22 +253,30 @@ def test_add_collaborator_view_with_gestion_profile(
         print(error)
 
 
-@pytest.mark.parametrize(
-    "custom_dict", [location_attributes_dict_1, location_attributes_dict_2]
-)
-def test_add_location_view_with_commercial_profile(
-    get_runner, get_valid_decoded_token_for_a_commercial_collaborator, custom_dict
+def test_add_valid_location_view_with_commercial_profile(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     """
-    Vérifier si un membre du service commercial peut ajouter une localité.
+    Vérifier si un membre du service commercial peut ajouter une localité valide.
     """
     try:
         db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_location(custom_dict)
+        result = ConsoleClientForCreate(db_name).add_location(location_attributes_dict_1)
         assert isinstance(result, int)
         assert result > 0
     except Exception as error:
         print(error)
+
+
+def test_add_unvalid_location_view_with_commercial_profile(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
+):
+    """
+    Vérifier si un membre du service commercial peut ajouter une localité invalide.
+    """
+    with pytest.raises(exceptions.SuppliedDataNotMatchModel):
+        db_name = f"{settings.TEST_DATABASE_NAME}"
+        result = ConsoleClientForCreate(db_name).add_location(location_attributes_dict_2)
 
 
 @pytest.mark.parametrize(
@@ -280,13 +288,9 @@ def test_add_location_view_with_gestion_profile(
     """
     Vérifier si un membre du service gestion peut ajouter une localité.
     """
-    try:
+    with pytest.raises(exceptions.InsufficientPrivilegeException):
         db_name = f"{settings.TEST_DATABASE_NAME}"
         result = ConsoleClientForCreate(db_name).add_location(custom_dict)
-        assert isinstance(result, int)
-        assert result > 0
-    except Exception as error:
-        print(error)
 
 
 @pytest.mark.parametrize(
@@ -298,13 +302,9 @@ def test_add_location_view_with_support_profile(
     """
     Vérifier si un membre du service support peut ajouter une localité.
     """
-    try:
+    with pytest.raises(exceptions.InsufficientPrivilegeException):
         db_name = f"{settings.TEST_DATABASE_NAME}"
         result = ConsoleClientForCreate(db_name).add_location(custom_dict)
-        assert isinstance(result, int)
-        assert result > 0
-    except Exception as error:
-        print(error)
 
 
 @pytest.mark.parametrize(

--- a/tests/views/test_update_views.py
+++ b/tests/views/test_update_views.py
@@ -42,7 +42,7 @@ client_partial_dict_4 = {
 }
 
 collaborator_partial_dict = {
-    "registration_number": "rr123456789",
+    "registration_number": "ad123456789",
     "username": "marianne de lagraine",
 }
 
@@ -81,7 +81,7 @@ contract_partial_dict4 = {
 }
 
 location_partial_dict = {
-    "location_id": "CAL13540",
+    "location_id": "p22240",
     "complement_adresse": "allée de la patissière",
 }
 
@@ -259,7 +259,7 @@ def test_update_event_view_with_gestion_profile(
 
 
 def test_update_event_view_with_support_profile_when_collaborator_is_assigned(
-    get_runner, get_valid_decoded_token_for_a_support_collaborator, dummy_event_partial_data_2
+    get_runner, get_valid_decoded_token_for_a_support_collaborator_with_id_5, dummy_event_partial_data_2
 ):
     """
     Description:

--- a/tests/views/test_z_delete_views.py
+++ b/tests/views/test_z_delete_views.py
@@ -19,7 +19,7 @@ except ModuleNotFoundError:
     from settings import settings
 
 
-def test_delete_client_view_with_commercial_profile(
+def test_delete_client_view_with_commercial_profile_when_client_not_referenced_in_contract(
     get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     try:
@@ -32,18 +32,25 @@ def test_delete_client_view_with_commercial_profile(
         print(error)
 
 
-def test_delete_client_view_with_support_profile(
+def test_delete_client_view_with_commercial_profile_when_client_referenced_in_contract_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client("mkc111")
+
+
+def test_delete_client_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client("poabm")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client("poabm")
 
 
-def test_delete_client_view_with_gestion_profile(
+def test_delete_client_view_with_gestion_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_gestion_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client("poabm")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client("poabm")
 
 
 def test_delete_company_view_with_commercial_profile(
@@ -59,32 +66,39 @@ def test_delete_company_view_with_commercial_profile(
         print(error)
 
 
-def test_delete_company_view_with_gestion_profile(
+def test_delete_company_view_with_commercial_profile_when_company_referenced_by_client_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_company("CSLLC12345")
+
+
+def test_delete_company_view_with_gestion_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_gestion_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_company("abm99998")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_company("abm99998")
 
 
-def test_delete_company_view_with_support_profile(
+def test_delete_company_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_company("abm99998")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_company("abm99998")
 
 
-def test_delete_contract_view_with_commercial_profile(
+def test_delete_contract_view_with_commercial_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_contract("C9Z1")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_contract("C9Z1")
 
 
-def test_delete_contract_view_with_support_profile(
+def test_delete_contract_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_contract("C9Z1")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_contract("C9Z1")
 
 
 def test_delete_contract_view_with_gestion_profile(
@@ -100,18 +114,25 @@ def test_delete_contract_view_with_gestion_profile(
         print(error)
 
 
-def test_delete_event_view_with_commercial_profile(
+def test_delete_contract_view_with_gestion_profile_when_contract_referenced_in_event_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_gestion_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_contract("kc555")
+
+
+def test_delete_event_view_with_commercial_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event("EV971")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event("EV971")
 
 
-def test_delete_event_view_with_support_profile(
+def test_delete_event_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event("geg2021")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_event("geg2021")
 
 
 def test_delete_event_view_with_gestion_profile(
@@ -127,25 +148,32 @@ def test_delete_event_view_with_gestion_profile(
         print(error)
 
 
-def test_delete_location_view_with_gestion_profile(
+def test_delete_location_view_with_gestion_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_gestion_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_location("CAL13540")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_location("CAL13540")
 
 
-def test_delete_location_view_with_support_profile(
+def test_delete_location_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_location("CAL13540")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_location("CAL13540")
 
 
-def test_delete_location_view_with_commercial_profile(
+def test_delete_location_view_with_commercial_profile_when_location_referenced_by_company_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_location("p22240")
+
+
+def test_delete_location_view_with_commercial_profile_when_location_not_referenced_by_company(
     get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     try:
-        dummy_locations_list = ["CAL13540", "PL24250"]
+        dummy_locations_list = ["PL24250"]
         for location in dummy_locations_list:
             result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_location(location)
             assert isinstance(result, int)
@@ -167,18 +195,25 @@ def test_delete_role_view_with_gestion_profile(
         print(error)
 
 
-def test_delete_role_view_with_commercial_profile(
+def test_delete_role_view_with_gestion_profile_when_role_referenced_in_collaborator_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_gestion_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_role("emp")
+
+
+def test_delete_role_view_with_commercial_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_role("sec")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_role("sec")
 
 
-def test_delete_role_view_with_support_profile(
+def test_delete_role_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_role("sec")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_role("sec")
 
 
 def test_delete_department_view_with_gestion_profile(
@@ -194,50 +229,39 @@ def test_delete_department_view_with_gestion_profile(
         print(error)
 
 
-def test_delete_department_view_with_support_profile(
+def test_delete_department_view_with_gestion_profile_when_department_referenced_in_collaborator_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_gestion_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_department("ccial")
+
+
+def test_delete_department_view_with_support_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_department("design")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_department("design")
 
 
-def test_delete_department_view_with_commercial_profile(
+def test_delete_department_view_with_commercial_profile_raises_exception(
     get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_department("design")
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_department("design")
 
 
-@pytest.mark.parametrize("matricule", [
-    "ww123456789",
-    "xx123456789",
-    "yy123456789",
-    "pp123456789",
-    "qq123456789",
-    "rr123456789"
-    ]
-)
-def test_delete_collaborator_view_with_commercial_profile(
-    get_runner, get_valid_decoded_token_for_a_commercial_collaborator, matricule
+def test_delete_collaborator_view_with_commercial_profile_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_collaborator(matricule)
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_collaborator("ww123456789")
 
 
-@pytest.mark.parametrize("matricule", [
-    "ww123456789",
-    "xx123456789",
-    "yy123456789",
-    "pp123456789",
-    "qq123456789",
-    "rr123456789"
-    ]
-)
-def test_delete_collaborator_view_with_support_profile(
-    get_runner, get_valid_decoded_token_for_a_support_collaborator, matricule
+def test_delete_collaborator_view_with_support_profile_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_support_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
-        result = ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_collaborator(matricule)
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_collaborator("ww123456789")
 
 
 @pytest.mark.parametrize("matricule", [
@@ -258,3 +282,9 @@ def test_delete_collaborator_view_with_gestion_profile(
         assert result > 0
     except Exception as error:
         print(error)
+
+def test_delete_collaborator_view_with_gestion_profile_when_collaborator_referenced_in_contract_raises_exception(
+    get_runner, get_valid_decoded_token_for_a_gestion_collaborator
+):
+    with pytest.raises(exceptions.ForeignKeyDependyException):
+        ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_collaborator("aa123456789")


### PR DESCRIPTION
On vérifie qu'on ne peut pas supprimer d'élément dont la clef primaire est déjà référencée par un autre. 
On vérifie la levée de exceptions.ForeignKeyDependyException. 
On adapte les ids afin de permettre les tests. On allège le code en syntaxes inutiles.