### PR TITLE
Transfert appel de display_info_data_medium_window et display_info_da…

### DIFF
--- a/src/clients/info_console.py
+++ b/src/clients/info_console.py
@@ -4,6 +4,7 @@ Description: console dédiée aux commandes infos
 from rich import print
 
 try:
+    from src.controllers import infos_data_controller
     from src.controllers.infos_update_password_controller import (
         display_info_password_policy,
     )
@@ -12,6 +13,7 @@ try:
     from src.views.views import AppViews
     from src.views.jwt_view import JwtView
 except ModuleNotFoundError:
+    from controllers import infos_data_controller
     from controllers.infos_update_password_controller import (
         display_info_password_policy,
     )
@@ -38,7 +40,7 @@ class InformationConsoleClient:
     def display_info_password_policy(self):
         """
         Description:
-        Retourner la politique de mot de passe
+        Retourner la politique de mot de passe.
         """
         try:
             display_info_password_policy()
@@ -46,3 +48,20 @@ class InformationConsoleClient:
             print(
                 "[bold red]Erreur[/bold red] Absence de jeton."
             )
+
+    @authentication_permission_decorator
+    def display_info_data_medium_window_for_metiers(self):
+        """
+        Description:
+        Ouvrir la popup dédiée.
+        """
+        infos_data_controller.display_info_data_medium_window("metiers")
+
+
+    @authentication_permission_decorator
+    def display_info_data_medium_window_for_complement_adresse(self):
+        """
+        Description:
+        Ouvrir la popup dédiée.
+        """
+        infos_data_controller.display_info_data_thin_window("types_voies")

--- a/src/commands/infos_data_commands.py
+++ b/src/commands/infos_data_commands.py
@@ -3,11 +3,10 @@ Description: Toutes les commandes pour obtenir des infos sur les formats ou donn
 """
 import click
 from rich import print
-
 try:
-    from src.controllers import infos_data_controller
+    from src.clients.info_console import InformationConsoleClient
 except ModuleNotFoundError:
-    from controllers import infos_data_controller
+    from clients.info_console import InformationConsoleClient
 
 
 @click.command
@@ -16,9 +15,14 @@ def get_metiers():
     Description: commande dédiée à récupérer les métiers attendus pour un client.
     """
     try:
-        infos_data_controller.display_info_data_medium_window("metiers")
-    except Exception as error:
+        console_client = InformationConsoleClient()
+        console_client.display_info_data_medium_window_for_metiers()
+    except FileNotFoundError as error:
         print(f"[bold red]Problème avec le fichier[/bold red]: {error}")
+    except Exception:
+        print(
+            "[bold red]Erreur[/bold red] Absence de jeton. Executer 'oc12_token' pour en obtenir un."
+        )
 
 
 @click.command
@@ -27,6 +31,11 @@ def get_types_voies():
     Description: commande dédiée à récupérer les types de voirs attendus pour une adresse.
     """
     try:
-        infos_data_controller.display_info_data_thin_window("types_voies")
-    except Exception as error:
+        console_client = InformationConsoleClient()
+        console_client.display_info_data_medium_window_for_complement_adresse()
+    except FileNotFoundError as error:
         print(f"[bold red]Problème avec le fichier[/bold red]: {error}")
+    except Exception:
+        print(
+            "[bold red]Erreur[/bold red] Absence de jeton. Executer 'oc12_token' pour en obtenir un."
+        )


### PR DESCRIPTION
Transfert appel de display_info_data_medium_window et display_info_data_thin_window, vers 'src/clients/info_console.py' ce qui permet d'ajouter le décorateur 'authentication_permission_decorator' en critère implicite d'accès.