### PR TITLE
Retour l'id dans méthode get_dict. Méthode appelée lors d'une recherc…

### DIFF
--- a/src/models/models.py
+++ b/src/models/models.py
@@ -160,6 +160,7 @@ class Collaborator(Base):
 
     def get_dict(self):
         collaborator_dict = {
+            "id": self.id,
             "creation_date": self.creation_date,
             "registration_number": self.registration_number,
             "username": self.username,
@@ -475,6 +476,7 @@ class Event(Base):
             "title",
             "contract_id",
             "client_id",
+            "commercial_id",
             "collaborator_id",
             "event_start_date",
             "event_end_date",


### PR DESCRIPTION
Retour l'id dans méthode get_dict. Méthode appelée lors d'une recherche par custom_id depuis (/par) un autre modèle. On a besoin de récupérer l'id réel.