### PR TITLE
Tests besoins tous service. Il demeure des filtres à vérifier qui sor…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,24 @@ def get_valid_decoded_token_for_a_support_collaborator_with_id_7(mocker):
 
 
 @pytest.fixture
+def get_valid_decoded_token_for_a_support_collaborator_with_id_8(mocker):
+    expiration = datetime.utcnow() + timedelta(minutes=1)
+    dummy_payload_data = {
+        "registration_number": "ag123456789",
+        "username": "Kate Hastroff",
+        "department": "oc12_support",
+        "expiration": f'{expiration.strftime("%Y-%m-%d %H:%M:%S")}',
+    }
+    mocker.patch(
+        "controllers.jwt_controller.JwtController.get_decoded_token",
+        return_value=dummy_payload_data,
+    )
+    mocker.patch.object(JwtController, "does_a_valid_token_exist", return_value=True)
+    mocker.patch.object(JwtView, "get_decoded_token", return_value=dummy_payload_data)
+    return dummy_payload_data
+
+
+@pytest.fixture
 def get_unvalid_decoded_token(mocker):
     dummy_payload_data = {
         "registration_number": "Zaa123456789",
@@ -169,7 +187,22 @@ def dummy_client_data(request):
         "email": "d.duck@abm.fr",
         "telephone": "0655228844",
         "company_id": "1",
-        "commercial_contact": "2",
+    }
+    return client
+
+
+@pytest.fixture(scope="session", autouse=True)
+def dummy_client_data_2(request):
+    client = {
+        "creation_date": f"{datetime.now()}",
+        "client_id": "bduck",
+        "civility": "MR",
+        "first_name": "Bernard",
+        "last_name": "duck",
+        "employee_role": "logistic officer",
+        "email": "baba.duck@abm.fr",
+        "telephone": "064465238977",
+        "company_id": "1",
     }
     return client
 
@@ -268,19 +301,39 @@ def dummy_contract_partial_data(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
+def dummy_contract_partial_data_2(request):
+    contract = {
+        "contract_id": "av123",
+        "remain_amount_to_pay": "155.6",
+        "status": "canceled",
+    }
+    return contract
+
+
+@pytest.fixture(scope="session", autouse=True)
+def dummy_contract_partial_data_3(request):
+    contract = {
+        "contract_id": "ax312",
+        "remain_amount_to_pay": "355.6",
+        "status": "canceled",
+    }
+    return contract
+
+
+@pytest.fixture(scope="session", autouse=True)
 def dummy_event_data(request):
     event = {
         "creation_date": "2023-07-14 09:05:10",
         "event_id": "EV971",
         "title": "What a Swing",
         "attendees": "2500",
-        "notes": "Bla bla bla bla bla bla dummy bla. As expected anything bu a bla.",
+        "notes": "Evènement avec partenariats autres associations locales.",
         "event_start_date": "2023-07-15 20:00:00",
         "event_end_date": "2023-07-15 22:00:00",
         "client_id": "1",
         "contract_id": "1",
         "location_id": "2",
-        "collaborator_id": "2",
+        "collaborator_id": "5",
     }
     return event
 
@@ -322,6 +375,16 @@ def dummy_event_partial_data_3(request):
         "event_id": "geg2021",
         "attendees": "2500",
         "notes": "Prévoir eau plate et gazeuse.",
+    }
+    return event_partial_dict
+
+
+@pytest.fixture(scope="session", autouse=True)
+def dummy_client_partial_data(request):
+    event_partial_dict = {
+        "client_id": "bduck",
+        "telephone": "0011223344",
+        "first_name": "Baba"
     }
     return event_partial_dict
 

--- a/tests/functional_tests/test_besoins_service_commercial.py
+++ b/tests/functional_tests/test_besoins_service_commercial.py
@@ -6,51 +6,104 @@ import pytest
 try:
     from src.clients.create_console import ConsoleClientForCreate
     from src.clients.delete_console import ConsoleClientForDelete
+    from src.clients.read_console import ConsoleClientForRead
     from src.clients.update_console import ConsoleClientForUpdate
     from src.exceptions import exceptions
     from src.settings import settings
 except ModuleNotFoundError:
     from clients.create_console import ConsoleClientForCreate
     from clients.delete_console import ConsoleClientForDelete
+    from clients.read_console import ConsoleClientForRead
     from clients.update_console import ConsoleClientForUpdate
     from exceptions import exceptions
     from settings import settings
 
 
 def test_client_creation_manipulation(
+    set_a_test_env,
     get_runner,
     get_valid_decoded_token_for_a_commercial_collaborator,
+    dummy_client_data_2,
     ):
     """
     Description:
     Un membre du service Commercial doit pouvoir créer des clients (le client leur sera automatiquement associé).
     """
-    pass
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_client(dummy_client_data_2)
+    assert isinstance(result, str)
+
+    current_commercial_user = get_valid_decoded_token_for_a_commercial_collaborator["registration_number"]
+    collaborators = ConsoleClientForRead(db_name).get_collaborators()
+    id_current_commercial_user = ""
+    for collaborator in collaborators:
+        if collaborator.registration_number == current_commercial_user:
+            id_current_commercial_user = collaborator.id
+            break
+
+    clients = ConsoleClientForRead(db_name).get_clients(('client_id=bduck',))
+    id_commercial_contact = ""
+    for client in clients:
+        if client.client_id == "bduck":
+            id_commercial_contact = client.commercial_contact
+            break
+    assert id_current_commercial_user == id_commercial_contact
 
 
 def test_client_update_manipulation(
+    set_a_test_env,
     get_runner,
     get_valid_decoded_token_for_a_commercial_collaborator,
+    dummy_client_partial_data
     ):
     """
     Description:
     Un membre du service Commercial doit pouvoir mettre à jour les clients dont il est responsable.
     """
-    pass
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForUpdate(db_name).update_client(dummy_client_partial_data)
+    assert isinstance(result, str)
+
+    clients = ConsoleClientForRead(db_name).get_clients(('client_id=bduck',))
+    client_updated = ""
+    for client in clients:
+        if client.client_id == "bduck":
+            client_updated = client
+            break
+    assert client_updated.telephone == dummy_client_partial_data["telephone"]
+    assert client_updated.first_name == dummy_client_partial_data["first_name"]
 
 
 def test_contract_update_manipulation(
+    set_a_test_env,
     get_runner,
     get_valid_decoded_token_for_a_commercial_collaborator,
+    dummy_contract_partial_data_2
     ):
     """
     Description:
     Un membre du service Commercial doit pouvoir mettre à jour les contrats des clients dont il est responsable.
     """
-    pass
+    id_updated_contract = dummy_contract_partial_data_2["contract_id"]
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForRead(db_name).get_contracts()
+    assert isinstance(result, list)
+
+    result = ConsoleClientForUpdate(db_name).update_contract(dummy_contract_partial_data_2)
+    assert isinstance(result, str)
+
+    contracts = ConsoleClientForRead(db_name).get_contracts((f'contract_id={id_updated_contract}',))
+    contract_updated = ""
+    for contract in contracts:
+        if contract.contract_id == f"{id_updated_contract}":
+            contract_updated = contract
+            break
+    assert float(contract_updated.remain_amount_to_pay) == float(dummy_contract_partial_data_2["remain_amount_to_pay"])
+    assert contract_updated.status == dummy_contract_partial_data_2["status"]
 
 
 def test_contract_display_manipulation(
+    set_a_test_env,
     get_runner,
     get_valid_decoded_token_for_a_commercial_collaborator,
     ):
@@ -59,10 +112,16 @@ def test_contract_display_manipulation(
     Un membre du service Commercial doit pouvoir filtrer l’affichage des contrats, par exemple :
     afficher tous les contrats qui ne sont pas encore signés, ou qui ne sont pas encore entièrement payés.
     """
-    pass
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    unsigned_contracts = ConsoleClientForRead(db_name).get_contracts(('status=unsigned',))
+    assert isinstance(unsigned_contracts, list)
+
+    unpaid_contracts = ConsoleClientForRead(db_name).get_contracts(('remain_amount_to_pay>0',))
+    assert isinstance(unpaid_contracts, list)
 
 
 def test_event_creation_manipulation(
+    set_a_test_env,
     get_runner,
     get_valid_decoded_token_for_a_commercial_collaborator,
     ):
@@ -70,4 +129,33 @@ def test_event_creation_manipulation(
     Description:
     Un membre du service Commercial doit pouvoir créer un événement pour un de leurs clients qui a signé un contrat.
     """
-    pass
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    event_dict = {
+        "creation_date": "2023-07-14 09:05:10",
+        "event_id": "fvc4440",
+        "title": "Faites vous cuisiner",
+        "attendees": "325",
+        "notes": "Prévoir au moins 3 type de plats /cuisines. Rester dans l'esprit de l'évènement.",
+        "event_start_date": "2024-02-15 18:00:00",
+        "event_end_date": "2024-02-15 23:00:00",
+        "client_id": "",
+        "contract_id": "",
+        "location_id": "2",
+        "collaborator_id": None,
+    }
+    clients = ConsoleClientForRead(db_name).get_clients(('client_id=bduck',))
+    client_for_event = ""
+    for client in clients:
+        if client.client_id == "bduck":
+            client_for_event = client
+            break
+    event_dict["client_id"] = client_for_event.id
+    contracts = ConsoleClientForRead(db_name).get_contracts()
+    contract_for_event = ""
+    for contract in contracts:
+        if contract.contract_id == "av123":
+            contract_for_event = contract
+            break
+    event_dict["contract_id"] = contract_for_event.id
+    result = ConsoleClientForCreate(db_name).add_event(event_dict)
+    assert isinstance(result, str)

--- a/tests/functional_tests/test_besoins_service_gestion.py
+++ b/tests/functional_tests/test_besoins_service_gestion.py
@@ -26,7 +26,8 @@ os.environ[f"{settings.PATH_APPLICATION_ENV_NAME}"] = "TEST"
 
 
 def test_collaborator_manipulation(
-    get_runner, set_a_test_env,
+    get_runner,
+    set_a_test_env,
     dummy_collaborator_data_2,
     get_valid_decoded_token_for_a_gestion_collaborator,
     dummy_collaborator_partial_data
@@ -51,7 +52,8 @@ def test_collaborator_manipulation(
 
 
 def test_contract_manipulation(
-    get_runner, set_a_test_env,
+    get_runner,
+    set_a_test_env,
     dummy_contract_data_2,
     get_valid_decoded_token_for_a_gestion_collaborator,
     dummy_contract_partial_data
@@ -77,7 +79,8 @@ def test_contract_manipulation(
 
 
 def test_event_display_manipulation(
-    get_runner, set_a_test_env,
+    get_runner,
+    set_a_test_env,
     get_valid_decoded_token_for_a_gestion_collaborator,
     dummy_event_partial_data_4
     ):
@@ -93,7 +96,8 @@ def test_event_display_manipulation(
 
 
 def test_event_update_manipulation(
-    get_runner, set_a_test_env,
+    get_runner,
+    set_a_test_env,
     get_valid_decoded_token_for_a_gestion_collaborator,
     dummy_event_partial_data_1,
     ):

--- a/tests/functional_tests/test_besoins_service_support.py
+++ b/tests/functional_tests/test_besoins_service_support.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
 
 
 def test_event_display_manipulation(
+    set_a_test_env,
     get_runner,
     get_valid_decoded_token_for_a_support_collaborator,
     dummy_event_partial_data_4
@@ -39,13 +40,14 @@ def test_event_display_manipulation(
 @pytest.mark.parametrize(
     "events_id",
     [
-        "geg2022",
-        "zawx235",
+        "dkap520",
+        "ay322",
     ]
 )
 def test_event_update_manipulation(
+    set_a_test_env,
     get_runner,
-    get_valid_decoded_token_for_a_support_collaborator_with_id_7,
+    get_valid_decoded_token_for_a_support_collaborator_with_id_8,
     events_id
     ):
     """

--- a/tests/views/test_create_views.py
+++ b/tests/views/test_create_views.py
@@ -105,7 +105,6 @@ client_attributes_dict_1 = {
     "email": "j.doe@abm.fr",
     "telephone": "0611223344",
     "company_id": "1",
-    "commercial_contact": "2",
     "creation_date": f"{datetime.now()}",
 }
 
@@ -118,7 +117,6 @@ client_attributes_dict_2 = {
     "email": "d.duck@abm.fr",
     "telephone": "0655228844",
     "company_id": "1",
-    "commercial_contact": "2",
     "creation_date": f"{datetime.now()}",
 }
 
@@ -196,9 +194,9 @@ event_attributes_dict_1 = {
     "event_start_date": "2023-07-15 20:00:00",
     "event_end_date": "2023-07-15 22:00:00",
     "client_id": "1",
-    "contract_id": "1",
+    "contract_id": "6",
     "location_id": "2",
-    "collaborator_id": "1",
+    "collaborator_id": "7",
     "creation_date": f"{datetime.now()}",
 }
 
@@ -210,9 +208,9 @@ event_attributes_dict_2 = {
     "event_start_date": "2023-07-23 19:30:00",
     "event_end_date": "2023-07-23 23:00:00",
     "client_id": "1",
-    "contract_id": "1",
+    "contract_id": "2",
     "location_id": "2",
-    "collaborator_id": "2",
+    "collaborator_id": "6",
     "creation_date": f"{datetime.now()}",
 }
 
@@ -249,7 +247,7 @@ role_attributes_dict_2 = {
         support_collaborator_attributes_dict_1,
     ],
 )
-def test_add_collaborator_view_with_commercial_profile(
+def test_add_collaborator_view_with_commercial_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_commercial_collaborator, custom_dict
 ):
     """
@@ -268,7 +266,7 @@ def test_add_collaborator_view_with_commercial_profile(
         support_collaborator_attributes_dict_1,
     ],
 )
-def test_add_collaborator_view_with_support_profile(
+def test_add_collaborator_view_with_support_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_support_collaborator, custom_dict
 ):
     """
@@ -296,12 +294,9 @@ def test_add_collaborator_view_with_gestion_profile(
     """
     Vérifier si un membre du service gestion peut ajouter un collaborateur.
     """
-    try:
-        db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_collaborator(custom_dict)
-        assert isinstance(result, str)
-    except Exception as error:
-        print(error)
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_collaborator(custom_dict)
+    assert isinstance(result, str)
 
 
 def test_add_valid_location_view_with_commercial_profile(
@@ -331,7 +326,7 @@ def test_add_unvalid_location_view_with_commercial_profile_raises_exception(
 @pytest.mark.parametrize(
     "custom_dict", [location_attributes_dict_1, location_attributes_dict_2]
 )
-def test_add_location_view_with_gestion_profile(
+def test_add_location_view_with_gestion_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_gestion_collaborator, custom_dict
 ):
     """
@@ -345,7 +340,7 @@ def test_add_location_view_with_gestion_profile(
 @pytest.mark.parametrize(
     "custom_dict", [location_attributes_dict_1, location_attributes_dict_2]
 )
-def test_add_location_view_with_support_profile(
+def test_add_location_view_with_support_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_support_collaborator, custom_dict
 ):
     """
@@ -362,12 +357,9 @@ def test_add_company_id_1_view_with_commercial_profile_with_valid_company(
     """
     Vérifier si un membre du service commercial peut ajouter une entreprise.
     """
-    try:
-        db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_company(company_attributes_dict_1)
-        assert isinstance(result, str)
-    except Exception as error:
-        print(error)
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_company(company_attributes_dict_1)
+    assert isinstance(result, str)
 
 
 def test_add_company_id_3_view_with_commercial_profile_with_valid_company(
@@ -376,13 +368,9 @@ def test_add_company_id_3_view_with_commercial_profile_with_valid_company(
     """
     Vérifier si un membre du service commercial peut ajouter une entreprise.
     """
-    try:
-        db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_company(company_attributes_dict_3)
-        assert isinstance(result, str)
-
-    except Exception as error:
-        print(error)
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_company(company_attributes_dict_3)
+    assert isinstance(result, str)
 
 
 @pytest.mark.parametrize(
@@ -394,12 +382,10 @@ def test_add_company_view_with_gestion_profile(
     """
     Vérifier si un membre du service gestion peut ajouter une entreprise.
     """
-    try:
+    with pytest.raises(exceptions.InsufficientPrivilegeException):
         db_name = f"{settings.TEST_DATABASE_NAME}"
         result = ConsoleClientForCreate(db_name).add_company(custom_dict)
         assert isinstance(result, str)
-    except Exception as error:
-        print(error)
 
 
 @pytest.mark.parametrize(
@@ -411,19 +397,16 @@ def test_add_company_view_with_support_profile(
     """
     Vérifier si un membre du service support peut ajouter une entreprise.
     """
-    try:
+    with pytest.raises(exceptions.InsufficientPrivilegeException):
         db_name = f"{settings.TEST_DATABASE_NAME}"
         result = ConsoleClientForCreate(db_name).add_company(custom_dict)
         assert isinstance(result, str)
-
-    except Exception as error:
-        print(error)
 
 
 @pytest.mark.parametrize(
     "custom_dict", [contract_attributes_dict_1, contract_attributes_dict_2]
 )
-def test_add_contract_view_with_commercial_profile(
+def test_add_contract_view_with_commercial_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_commercial_collaborator, custom_dict
 ):
     """
@@ -451,7 +434,7 @@ def test_add_contract_view_with_gestion_profile(
 @pytest.mark.parametrize(
     "custom_dict", [contract_attributes_dict_1, contract_attributes_dict_2]
 )
-def test_add_contract_view_with_support_profile(
+def test_add_contract_view_with_support_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_support_collaborator, custom_dict
 ):
     """
@@ -485,7 +468,7 @@ def test_add_event_view_with_commercial_profile_when_unassigned_contract_raises_
     Vérifier si un membre du service commercial peut ajouter un évènement
     Il ne peut pas créer un évènement pour un contrat qu'il n'a pas signé
     """
-    with pytest.raises(exceptions.SupportCollaboratorIsNotAssignedToEvent):
+    with pytest.raises(exceptions.CommercialCollaboratorIsNotAssignedToContract):
         db_name = f"{settings.TEST_DATABASE_NAME}"
         result = ConsoleClientForCreate(db_name).add_event(event_attributes_dict_2)
 
@@ -493,7 +476,7 @@ def test_add_event_view_with_commercial_profile_when_unassigned_contract_raises_
 @pytest.mark.parametrize(
     "custom_dict", [event_attributes_dict_1, event_attributes_dict_2]
 )
-def test_add_event_view_with_gestion_profile(
+def test_add_event_view_with_gestion_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_gestion_collaborator, custom_dict
 ):
     """
@@ -507,7 +490,7 @@ def test_add_event_view_with_gestion_profile(
 @pytest.mark.parametrize(
     "custom_dict", [event_attributes_dict_1, event_attributes_dict_2]
 )
-def test_add_event_view_with_support_profile(
+def test_add_event_view_with_support_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_support_collaborator, custom_dict
 ):
     """
@@ -527,12 +510,9 @@ def test_add_role_view_with_gestion_profile(
     """
     Vérifier si un membre du service gestion peut ajouter un role.
     """
-    try:
-        db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_role(custom_dict)
-        assert isinstance(result, str)
-    except Exception as error:
-        print(error)
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_role(custom_dict)
+    assert isinstance(result, str)
 
 
 @pytest.mark.parametrize(
@@ -544,19 +524,15 @@ def test_add_department_view_with_gestion_profile(
     """
     Vérifier si un membre du service gestion peut ajouter un departement (service).
     """
-    try:
-        db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_department(custom_dict)
-        assert isinstance(result, str)
-
-    except Exception as error:
-        print(error)
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_department(custom_dict)
+    assert isinstance(result, str)
 
 
 @pytest.mark.parametrize(
     "custom_dict", [dpmt_attributes_dict_1, dpmt_attributes_dict_2]
 )
-def test_add_department_view_with_commercial_profile(
+def test_add_department_view_with_commercial_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_commercial_collaborator, custom_dict
 ):
     """
@@ -576,18 +552,15 @@ def test_add_client_view_with_commercial_profile(
     """
     Vérifier si un membre du service commercial peut ajouter un client.
     """
-    try:
-        db_name = f"{settings.TEST_DATABASE_NAME}"
-        result = ConsoleClientForCreate(db_name).add_client(custom_dict)
-        assert isinstance(result, str)
-    except Exception as error:
-        print(error)
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    result = ConsoleClientForCreate(db_name).add_client(custom_dict)
+    assert isinstance(result, str)
 
 
 @pytest.mark.parametrize(
     "custom_dict", [client_attributes_dict_1, client_attributes_dict_2]
 )
-def test_add_client_view_with_gestion_profile(
+def test_add_client_view_with_gestion_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_gestion_collaborator, custom_dict
 ):
     """
@@ -601,7 +574,7 @@ def test_add_client_view_with_gestion_profile(
 @pytest.mark.parametrize(
     "custom_dict", [client_attributes_dict_1, client_attributes_dict_2]
 )
-def test_add_client_view_with_support_profile(
+def test_add_client_view_with_support_profile_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_support_collaborator, custom_dict
 ):
     """

--- a/tests/views/test_z_delete_views.py
+++ b/tests/views/test_z_delete_views.py
@@ -16,11 +16,11 @@ except ModuleNotFoundError:
     from settings import settings
 
 
-def test_delete_client_view_with_commercial_profile_when_client_not_referenced_in_contract(
-    get_runner, set_a_test_env, get_valid_decoded_token_for_a_commercial_collaborator
+def test_delete_client_view_with_gestion_profile_when_client_not_referenced_in_contract(
+    get_runner, set_a_test_env, get_valid_decoded_token_for_a_gestion_collaborator
 ):
     try:
-        dummy_clients_list = ["dduck", "poabm"]
+        dummy_clients_list = ["dduck", "poabm", "bduck"]
         for client in dummy_clients_list:
             result = ConsoleClientForDelete(
                 db_name=f"{settings.TEST_DATABASE_NAME}"
@@ -33,7 +33,7 @@ def test_delete_client_view_with_commercial_profile_when_client_not_referenced_i
 def test_delete_client_view_with_commercial_profile_when_client_referenced_in_contract_raises_exception(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_commercial_collaborator
 ):
-    with pytest.raises(exceptions.ForeignKeyDependyException):
+    with pytest.raises(exceptions.InsufficientPrivilegeException):
         ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client(
             "mkc111"
         )
@@ -48,8 +48,8 @@ def test_delete_client_view_with_support_profile_raises_exception(
         )
 
 
-def test_delete_client_view_with_gestion_profile_raises_exception(
-    get_runner, set_a_test_env, get_valid_decoded_token_for_a_gestion_collaborator
+def test_delete_client_view_with_commercial_profile_raises_exception(
+    get_runner, set_a_test_env, get_valid_decoded_token_for_a_commercial_collaborator
 ):
     with pytest.raises(exceptions.InsufficientPrivilegeException):
         ConsoleClientForDelete(db_name=f"{settings.TEST_DATABASE_NAME}").delete_client(
@@ -158,7 +158,7 @@ def test_delete_event_view_with_gestion_profile(
     get_runner, set_a_test_env, get_valid_decoded_token_for_a_gestion_collaborator
 ):
     try:
-        dummy_events_list = ["EV971"]
+        dummy_events_list = ["EV971", "fvc4440"]
         for event in dummy_events_list:
             result = ConsoleClientForDelete(
                 db_name=f"{settings.TEST_DATABASE_NAME}"


### PR DESCRIPTION
Tests besoins tous service. Il demeure des filtres à vérifier qui sortent du cahier des charges, ca concerne les filtres de custom_id pour des modèles non rattachés en clefs étrangères.