### PR TITLE
Renvoie None explicite quand aucune localité égale à un custom_id. C'…

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -653,7 +653,10 @@ def get_location_id_from_location_custom_id(session, location_id):
         f"""SELECT id FROM location WHERE location_id='{location_id}'"""
     )
     result = session.execute(sql).first()
-    id = str(result[0]).lower()
+    try:
+        id = str(result[0]).lower()
+    except TypeError:
+        id = None
     return id
 
 


### PR DESCRIPTION
Renvoie None explicite quand aucune localité égale à un custom_id. 
C'est utilisé lors de la procédure d'import de données externe depuis une API pour les entreprises Françaises, telle que proposée. 
On aura n entreprises à parcourir, chacune venant avec une localité. 
On va créer en bases (DEV et TEST) chaque localité et entreprise. On vérifiera que la localité n'existe pas déjà avant de la créer.