### PR TITLE
Event: vérifier qu'on ne peut seuelement assigner les membres du serv…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -396,6 +396,12 @@ def dummy_event_partial_data_4(request):
 
 
 @pytest.fixture(scope="session", autouse=True)
+def dummy_event_partial_data_5(request):
+    event_partial_dict = {"event_id": "hob2023", "collaborator_id": "1"}
+    return event_partial_dict
+
+
+@pytest.fixture(scope="session", autouse=True)
 def dummy_location_data(request):
     location = {
         "creation_date": "2023-07-14 09:05:10",

--- a/tests/functional_tests/test_besoins_service_gestion.py
+++ b/tests/functional_tests/test_besoins_service_gestion.py
@@ -110,3 +110,20 @@ def test_event_update_manipulation(
     result = ConsoleClientForUpdate(db_name=db_name).update_event(dummy_event_partial_data_1)
     assert isinstance(result, str)
     assert "Update" in result
+
+
+def test_event_update_manipulation_raise_exception(
+    get_runner,
+    set_a_test_env,
+    get_valid_decoded_token_for_a_gestion_collaborator,
+    dummy_event_partial_data_5,
+    ):
+    """
+    Description:
+    Un membre du service Gestion doit pouvoir modifier des événements (pour associer un collaborateur support à
+    l’événement).
+    Seul un membre du service Support doit pouvoir etre ajouté.
+    """
+    db_name = f"{settings.TEST_DATABASE_NAME}"
+    with pytest.raises(exceptions.OnlySuportMemberCanBeAssignedToEventSupportException):
+        result = ConsoleClientForUpdate(db_name=db_name).update_event(dummy_event_partial_data_5)


### PR DESCRIPTION
Event: vérifier qu'on ne peut seuelement assigner les membres du service Support en 'collaborateur'.