### PR TITLE
Un client doit pouvoir exister sans commercial. Exception en double r…

### DIFF
--- a/src/commands/database_delete_commands.py
+++ b/src/commands/database_delete_commands.py
@@ -100,12 +100,7 @@ def delete_collaborator(collaborator_id):
         if settings.INTERNET_CONNECTION and settings.LOG_COLLECT_ACTIVATED:
             LOGGER.error(message)
     except exceptions.ForeignKeyDependyException:
-        message = APP_DICT.get_appli_dictionnary()[
-            "FOREIGNKEY_CONTRACT_CAN_NOT_BE_DROP"
-        ]
-        printer.print_message("error", message)
-        if settings.INTERNET_CONNECTION and settings.LOG_COLLECT_ACTIVATED:
-            LOGGER.error(message)
+        pass
     except exceptions.InsufficientPrivilegeException:
         message = APP_DICT.get_appli_dictionnary()["INSUFFICIENT_PRIVILEGES_EXCEPTION"]
         printer.print_message("error", message)

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -292,7 +292,7 @@ class Client(Base):
     company_id = Column(Integer, ForeignKey("company.id"))
     creation_date = Column(Date(), nullable=False, default=date.today())
     last_update_date = Column(Date(), nullable=False, default=datetime.now())
-    commercial_contact = Column(Integer, ForeignKey("collaborator.id"), nullable=False)
+    commercial_contact = Column(Integer, ForeignKey("collaborator.id"), nullable=True)
     # ajout "passive_deletes='all'" pour éviter qu'on puisse supprimer un client si référencée par un collaborateur
     collaborator = relationship(
         "Collaborator", back_populates="client", passive_deletes="all"
@@ -317,7 +317,11 @@ class Client(Base):
         descriptors += f"µ(email|{self.email})"
         descriptors += f"µ(telephone|{self.telephone})"
         descriptors += f"µ(company_id|{self.company.company_id})"
-        descriptors += f"µ(commercial_contact|{self.collaborator.registration_number})"
+        descriptors += (
+            f"µ(commercial_contact|{self.collaborator.registration_number})"
+            if self.commercial_contact is not None
+            else "µ(commercial_contact|None)"
+        )
         descriptors += "]"
         return descriptors
 
@@ -386,6 +390,8 @@ class Contract(Base):
         descriptors += f"µ(client_id|{self.client.client_id})"
         descriptors += (
             f"µ(collaborator_id|{self.client.collaborator.registration_number})"
+            if self.client.collaborator is not None
+            else "µ(commercial_id|None)"
         )
         descriptors += f"µ(status|{self.status})"
         descriptors += f"µ(full_amount_to_pay|{self.full_amount_to_pay}{settings.DEFAULT_CURRENCY[1]})"

--- a/src/views/clients_view.py
+++ b/src/views/clients_view.py
@@ -101,6 +101,10 @@ class ClientsView:
          - user_service: chaine de caractère, le nom du service de l'utilisateur courant (exemple: oc12_commercial)
          - custom_dict: un dictionnaire avec l'id et des données optionnelles.
         """
+        if "commercial_contact" in custom_dict.keys():
+            if custom_dict["commercial_contact"] != None:
+                collaborator_id = utils.get_user_id_from_registration_number(self.session, custom_dict["commercial_contact"])
+                custom_dict["commercial_contact"] = collaborator_id
         return self.db_controller.update_client(
             self.session, current_user_collaborator_id, user_service, custom_dict
         )


### PR DESCRIPTION
Un client doit pouvoir exister sans commercial. Exception en double retirée. Mise à jour pour cas changement commercial pour client.